### PR TITLE
Deprecate global service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,11 @@
 
 No changes at this moment.
 
-## [1.0-alpha2]
+## [1.3]
 
-- Improved documentation.
-- Improved code quality.
-- Added container injection support for plugins.
-- Removed request() method from JsldPathPlugin, use container injection instead.
-- Improved plugin generators for Drush. Now they with examples of container injection.
-- From now, each structured data from plugin will have a personal script tag with data, not all in one place.
-- Refactored Drush generator command `drush generate jsld`.
-- Added predefined examples for common structured data type when using drush generator.
+### Changed
 
-[1.0-alpha2]: https://github.com/Niklan/jsld/compare/8.x-1.0-alpha1...8.x-1.0-alpha2
+- `JsldGlobal` service is depricated. He basically has no use.
+- Schema moved to the `html_head`, because of problems with the caching in the footer. `#attached` is processed properly no matter what, while `page_bottom` is heavily cached. This is visible on multilingual websites.
+
+[1.3]: https://github.com/Niklan/jsld/compare/8.x-1.2...8.x-1.3

--- a/jsld.module
+++ b/jsld.module
@@ -27,8 +27,17 @@ function jsld_entity_view(array &$build, EntityInterface $entity, EntityViewDisp
         ]);
 
         if ($instance->isEnabled()) {
-          $jsld_global = \Drupal::service('jsld.global');
-          $jsld_global->add($instance->build());
+          $build['#attached']['html_head'][] = [
+            [
+              '#type' => 'html_tag',
+              '#tag' => 'script',
+              '#attributes' => [
+                'type' => 'application/ld+json',
+              ],
+              '#value' => Json::encode($instance->build()),
+            ],
+            "jsld_{$plugin_id}",
+          ];
         }
       }
     }
@@ -46,7 +55,7 @@ function jsld_entity_limit($bundle, $view_mode, $limits = []) {
       continue;
     }
 
-    list($limit_bundle, $limit_view_mode) = explode('|', $limit);
+    [$limit_bundle, $limit_view_mode] = explode('|', $limit);
     if (($bundle == $limit_bundle || $limit_bundle == '*') && ($view_mode == $limit_view_mode || $limit_view_mode == '*')) {
       $valid = TRUE;
       break;
@@ -85,26 +94,19 @@ function jsld_preprocess_html(&$variables) {
       $instance = $plugin_service->createInstance($plugin_id);
 
       if ($instance->isEnabled()) {
-        $jsld_global->add($instance->build());
+        $variables['#attached']['html_head'][] = [
+          [
+            '#type' => 'html_tag',
+            '#tag' => 'script',
+            '#attributes' => [
+              'type' => 'application/ld+json',
+            ],
+            '#value' => Json::encode($instance->build()),
+          ],
+          "jsld_{$plugin_id}",
+        ];
       }
-    }
-  }
-
-  $jsld = $jsld_global->get();
-  if (!empty($jsld)) {
-    foreach ($jsld as $jsld_structured_data) {
-      if (empty($jsld_structured_data)) {
-        continue;
-      }
-      
-      $variables['page_bottom'][] = [
-        '#type' => 'html_tag',
-        '#tag' => 'script',
-        '#attributes' => [
-          'type' => 'application/ld+json',
-        ],
-        '#value' => Json::encode($jsld_structured_data),
-      ];
     }
   }
 }
+

--- a/src/EventSubscriber/JsldSubscriber.php
+++ b/src/EventSubscriber/JsldSubscriber.php
@@ -9,6 +9,9 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * Event subscriber for initialisation of service.
+ *
+ * @deprecated since 1.3, since it has issues with caching. Will be removed in
+ *    2.0+.
  */
 class JsldSubscriber implements EventSubscriberInterface {
 
@@ -50,3 +53,4 @@ class JsldSubscriber implements EventSubscriberInterface {
   }
 
 }
+

--- a/src/Service/JsldGlobal.php
+++ b/src/Service/JsldGlobal.php
@@ -4,6 +4,9 @@ namespace Drupal\jsld\Service;
 
 /**
  * Service to collect all data during request.
+ *
+ * @deprecated since 1.3, since it has issues with caching. Will be removed in
+ *   2.0+.
  */
 class JsldGlobal {
 
@@ -50,3 +53,4 @@ class JsldGlobal {
   }
 
 }
+


### PR DESCRIPTION
- It has issues with caching. Since `hook_entity_view()` is not called if entity rendered from cache, but `#attached` is preserved.
- There is no reason for that global storage, since there is no API for altering it or anything, so it won't hurt anyone by removal.
- Because of that, the JS-LD script tag was moved in head, since `#attached` doesn't support for page bottom, on;y `html_head`.